### PR TITLE
Only show drawing area when modifying object

### DIFF
--- a/src/views/app/editor/components/CanvasContainer.tsx
+++ b/src/views/app/editor/components/CanvasContainer.tsx
@@ -89,7 +89,11 @@ const CanvasContainer = ({
         width={{ base: 350, md: 500 }}
       />
       <Box
-        border={`2px dashed ${DARK_VARIANTS.includes(selectedVariant) ? "#FFFFFF" : "#a8a8a8"}`}
+        border={
+          isModifyingObject
+            ? `2px dashed ${DARK_VARIANTS.includes(selectedVariant) ? "#FFFFFF" : "#a8a8a8"}`
+            : "none"
+        }
         borderRadius="4px"
         left={`${drawingArea.left}px`}
         position="absolute"

--- a/src/views/app/editor/utils/template-export.ts
+++ b/src/views/app/editor/utils/template-export.ts
@@ -1,7 +1,7 @@
-import { toPng } from 'html-to-image';
-import { random } from 'lodash';
+import { toPng } from "html-to-image";
+import { random } from "lodash";
 
-import { saveTemplate } from '@/api/image-generator';
+import { saveTemplate } from "@/api/image-generator";
 
 const getTemplateImgFromHtml = async (element) => {
   // We have to do multiple calls before the actual call because the library has a concurrency issue on mobile Safari
@@ -17,32 +17,20 @@ const getEditorStateAsImages = () => {
    * The exporting library requires both sides of the template to be visible in the DOM.
    * We have to make them temporarily visible and then hide them.
    */
-  const front = document.getElementById('#canvas-container-front');
-  const back = document.getElementById('#canvas-container-back');
-  const drawingAreas = document.getElementsByClassName('drawing-area');
+  const front = document.getElementById("#canvas-container-front");
+  const back = document.getElementById("#canvas-container-back");
 
   const frontOld = front.style.display;
   const backOld = back.style.display;
-  const drawingAreaOld = (drawingAreas[0] as HTMLElement).style.border;
 
-  front.style.display = 'block';
-  back.style.display = 'block';
+  front.style.display = "block";
+  back.style.display = "block";
 
-  [...drawingAreas].forEach((element) => {
-    (element as HTMLElement).style.border = 'none';
-  });
-
-  const promises = [front, back].map((element) =>
-    getTemplateImgFromHtml(element)
-  );
+  const promises = [front, back].map((element) => getTemplateImgFromHtml(element));
 
   const reset = () => {
     front.style.display = frontOld;
     back.style.display = backOld;
-
-    [...drawingAreas].forEach((element) => {
-      (element as HTMLElement).style.border = drawingAreaOld;
-    });
   };
 
   return Promise.all(promises).then((dataUrls) => {
@@ -56,9 +44,7 @@ const getEditorStateAsImageUrls = () => {
   return getEditorStateAsImages().then((dataUrls) =>
     Promise.all(
       dataUrls.map((dataUrl) =>
-        saveTemplate(`Template-${Date.now()}-${random(10e9)}`, dataUrl).then(
-          ({ url }) => url
-        )
+        saveTemplate(`Template-${Date.now()}-${random(10e9)}`, dataUrl).then(({ url }) => url)
       )
     )
   );


### PR DESCRIPTION
### Description (what's changed?)

We're only showing the drawing area when you're modifying an object (rotating, moving etc.)

### Testing instructions

Notice that you don't see the drawing area anymore. Now add an image for example and rotate, move or scale it. Notice how the drawing area is visible while you're doing it.
