### PR TITLE
Extract the Toolbar container into a component

### DIFF
--- a/src/views/app/editor/components/ToolbarContainer.tsx
+++ b/src/views/app/editor/components/ToolbarContainer.tsx
@@ -1,0 +1,23 @@
+import { Box } from '@chakra-ui/react';
+
+type ToolbarContainerProps = {
+  children: React.ReactNode;
+};
+
+const ToolbarContainer = ({ children, ...rest }: ToolbarContainerProps) => (
+  <Box
+    bg="#FFFFFF"
+    boxShadow="0px 1px 2px 0px #0000000F"
+    id="object-edit-tools"
+    onClick={(e) => {
+      e.stopPropagation();
+    }}
+    overflow="auto"
+    p="12px 11px 8px 11px"
+    {...rest}
+  >
+    {children}
+  </Box>
+);
+
+export default ToolbarContainer;

--- a/src/views/app/editor/controls/index.tsx
+++ b/src/views/app/editor/controls/index.tsx
@@ -5,6 +5,8 @@ import ToolbarButton from '../components/ToolbarButton';
 import IconUndo from '@/components/icons/IconUndo';
 import IconRedo from '@/components/icons/IconRedo';
 
+import ToolbarContainer from '../components/ToolbarContainer';
+
 import { IconAddText, IconFlipProduct, IconSave } from './Icons';
 
 const SIDES = ['front', 'back'];
@@ -41,14 +43,7 @@ export default function Toolbar({
   selectedSide,
 }: Props) {
   return (
-    <Box
-      bg="#FFFFFF"
-      borderLeft={{ base: 'none', md: '1px solid rgba(26, 26, 26, 0.10)' }}
-      boxShadow="0px 0.7647058963775635px 1.529411792755127px 0px rgba(0, 0, 0, 0.06), 0px 0.7647058963775635px 2.2941176891326904px 0px rgba(0, 0, 0, 0.10)"
-      h={{ base: '70px', md: 'auto' }}
-      p={{ base: '20px 14px 10px 14px', md: '20px 14px' }}
-      w="100%"
-    >
+    <ToolbarContainer>
       <HStack justify="space-between" spacing="20px" w="100%">
         <HStack spacing="12px">
           <ToolbarButton
@@ -85,6 +80,6 @@ export default function Toolbar({
           <ToolbarButton icon={<IconSave />} onClick={onSave} text="Save" />
         </HStack>
       </HStack>
-    </Box>
+    </ToolbarContainer>
   );
 }

--- a/src/views/app/editor/object-edit-tools/index.tsx
+++ b/src/views/app/editor/object-edit-tools/index.tsx
@@ -22,6 +22,8 @@ import { AiImage } from '@/components/types';
 
 import Colors from '@/theme/colors';
 
+import ToolbarContainer from '../components/ToolbarContainer';
+
 import ColorPicker from './ColorPicker';
 import FontPicker from './FontPicker';
 
@@ -365,16 +367,7 @@ const ObjectEditTools = ({
   const mainAiImage = canvas._objects.find(({ aiImage }) => !!aiImage)?.aiImage;
 
   return (
-    <Box
-      bg="#FFFFFF"
-      boxShadow="0px 1px 2px 0px #0000000F"
-      id="object-edit-tools"
-      onClick={(e) => {
-        e.stopPropagation();
-      }}
-      overflow="auto"
-      p="12px 11px 8px 11px"
-    >
+    <ToolbarContainer>
       <HStack position="relative" spacing="6px">
         {isText ? (
           <F>
@@ -496,7 +489,7 @@ const ObjectEditTools = ({
           onClose={() => setErrorRemovingBackground(null)}
         />
       ) : null}
-    </Box>
+    </ToolbarContainer>
   );
 };
 


### PR DESCRIPTION
### Description (what's changed?)

Made a toolbar container component that can be used for various toolbar contexts in the editor. This also solves the issue where toolbars have a different height and look bouncy.

### Testing instructions

1. Open the editor. Generate an image. Click in and out of it. The toolbar won't jump.

