### PR TITLE
Hotfix/updating canvas dimensions on garment change

### DIFF
--- a/src/views/app/editor/EditorTool.tsx
+++ b/src/views/app/editor/EditorTool.tsx
@@ -98,7 +98,6 @@ export default function ImageEditorTool({ design, onDesignChange, onSave }: Imag
   }, [canvas, design, editorState, onDesignChange, selectedSide, undoStack]);
 
   useEffect(() => {
-    console.log('Use effect');
     sides.forEach((side) => {
       const canvas = side === 'front' ? canvasFront : canvasBack;
 
@@ -187,7 +186,11 @@ export default function ImageEditorTool({ design, onDesignChange, onSave }: Imag
       const { width, height } =
         product.printableAreas[side.toLowerCase()][isMobile ? 'base' : 'md'];
 
-      canvas.current.setDimensions({ width, height });
+      canvas.current.setDimensions({ height: height * 3, width: width * 3 });
+      canvas.current.setDimensions(
+        { height: `${height}px`, width: `${width}px` },
+        { cssOnly: true }
+      );
     });
   };
 
@@ -239,8 +242,6 @@ export default function ImageEditorTool({ design, onDesignChange, onSave }: Imag
       left: (width * 3) / 2,
       top: aiImage ? aiImage.aCoords.tl.y + aiImage.height : (height * 3) / 2 - 20,
     };
-
-    console.log('Text object', textObject);
 
     const text = new fabric.IText(textObject.text, textObject);
 


### PR DESCRIPTION
### Description (what's changed?)

This morning Rohan sent me two more videos showing the bug with enlarged canvas elements he discovered, including a new bug with adding text. This other bug me helped me figure out that both of them happened only when you switched the template in the middle of editing. In that case I have to update the canvas dimensions, but I have to upscale it. In the end it turned out to be a simple fix. 

I think that this should go out as a hotfix, as per Gitflow, because it turned out to be a critical bug in the end. We just didn't have steps to reproduce it.

### Testing instructions

1. Switch template in the editor to something else like a T Shirt
2. Add an image or text. Everything should work properly. 
