### PR TITLE
Add max text offset

### DIFF
--- a/src/views/app/editor/EditorTool.tsx
+++ b/src/views/app/editor/EditorTool.tsx
@@ -234,14 +234,6 @@ export default function ImageEditorTool({ design, onDesignChange, onSave }: Imag
 
     const aiImage = canvas.current._objects.find(({ aiImage }) => aiImage);
 
-    console.log(
-      'Add text',
-      aiImage.aCoords.tl.y,
-      aiImage.height,
-      aiImage.aCoords.tl.y + aiImage.height,
-      height
-    );
-
     const maxTextOffset = height * 3 - 20;
 
     const textObject = {


### PR DESCRIPTION
### Description (what's changed?)

Added a limit to where the text can be placed on the canvas in relation to the image. It can't go lower than the bottom of the canvsas.

### Testing instructions

1. Place an AI Image. Resize and move it to the bottom
2. Add text. It will appear at the bottom of the canvas and be visible.
