### PR TITLE
Fix color filters

### DIFF
--- a/src/views/app/editor/toolbar/product-picker/index.tsx
+++ b/src/views/app/editor/toolbar/product-picker/index.tsx
@@ -201,7 +201,7 @@ export default function ProductPicker({
           onApply={() => {
             setFiltersVisible(false);
 
-            onSelectedGarment({ ...selectedGarment, productId: null });
+            onSelectedGarment({ ...selectedGarment });
           }}
           onUpdate={(updates) => onFiltersChange({ ...filters, ...updates })}
         />


### PR DESCRIPTION
### Description (what's changed?)

Since the product picker is now a part of the editor, when filtering products we shouldn't reset the current product, even if it's filtered out.

### Testing instructions

1. Try to filter products by color
