### PR TITLE
Make touch area for resizing really big

### DIFF
--- a/src/theme/fabric.tsx
+++ b/src/theme/fabric.tsx
@@ -9,6 +9,7 @@ fabric.Object.prototype.set({
   borderRadius: '1px',
   cornerColor: abloBlue,
   cornerSize: 45,
+  touchCornerSize: 100,
 });
 
 fabric.Object.prototype.setControlsVisibility({


### PR DESCRIPTION
### Description (what's changed?)

Try to resize an image on mobile. It should feel good and work well. 

Note: the number for touch coordinates size I set in the PR doesn't actually increase those controls visually and I came up with it with experimentation. 


