### PR TITLE
Make default text bigger

### DIFF
--- a/src/views/app/editor/controls/index.tsx
+++ b/src/views/app/editor/controls/index.tsx
@@ -13,10 +13,10 @@ const SIDES = ['front', 'back'];
 
 const textProps = {
   editable: true,
-  fill: '#000000',
+  fill: '#00FF29',
   fontFamily: 'Poppins',
   text: '',
-  fontSize: 20,
+  fontSize: 46,
   textAlign: 'left',
   originX: 'center',
   originY: 'center',


### PR DESCRIPTION
### Description (what's changed?)

1. Made the default text bigger & neon in color
2. Centralized the text after user clicks "add text" and placing it below the image (this was already done before)
3. Pushing up the canvas up so it doesn't get hidden by keyboard (this was already done before)

Christian forfeited this requirement:  `Adding text field in the keyboard` because we can't modify native keyboad behaviour. For example, it works that way on my Android, but not on my iPhone
