### PR TITLE
Increase template width on Template Details

### DIFF
--- a/src/views/app/editor/toolbar/template-picker/TemplateDetails.tsx
+++ b/src/views/app/editor/toolbar/template-picker/TemplateDetails.tsx
@@ -65,7 +65,7 @@ const TemplateDetails = ({ garment, onGarmentUpdate, template }: TemplateDetails
         w="100%"
       >
         <IconSustainable position="absolute" right="14px" top="23px" />
-        <Image w={500} src={variant.images[0].url} alt={name} />
+        <Image w={{ base: 350, md: 500 }} src={variant.images[0].url} alt={name} />
       </Flex>
       <Box padding="24px 14px">
         <Text color="#959392" fontSize="sm" mb="13px">

--- a/src/views/app/editor/toolbar/template-picker/TemplateDetails.tsx
+++ b/src/views/app/editor/toolbar/template-picker/TemplateDetails.tsx
@@ -59,13 +59,13 @@ const TemplateDetails = ({ garment, onGarmentUpdate, template }: TemplateDetails
         bg={{ base: '#F9F9F7', md: 'transparent' }}
         direction="column"
         justify="center"
+        paddingTop="20px"
         position="relative"
         margin="0 auto"
-        h="271px"
         w="100%"
       >
         <IconSustainable position="absolute" right="14px" top="23px" />
-        <Image h={216} src={variant.images[0].url} alt={name} />
+        <Image w={500} src={variant.images[0].url} alt={name} />
       </Flex>
       <Box padding="24px 14px">
         <Text color="#959392" fontSize="sm" mb="13px">

--- a/src/views/app/editor/toolbar/template-picker/index.tsx
+++ b/src/views/app/editor/toolbar/template-picker/index.tsx
@@ -60,7 +60,7 @@ const TemplatesList = ({ templates, onSelectedTemplate, selectedGarment }: Templ
           {chunk.map((template, index) => {
             const { fabric, fit, id, name, price, colors } = template;
 
-            const variant = colors.find((variant) => variant.name === 'OatMilk');
+            const variant = colors.find((variant) => variant.name === 'OatMilk') || colors[0];
 
             const isSelected = selectedGarment && selectedGarment.templateId === id;
 


### PR DESCRIPTION
### Description (what's changed?)

Increased template width on Template Details

### Testing instructions

1. Select a template from the list on desktop. The image on the details view will be a lot bigger than before
