### PR TITLE
Set max height and overflow to template image

### DIFF
--- a/src/views/app/editor/EditorTool.tsx
+++ b/src/views/app/editor/EditorTool.tsx
@@ -507,12 +507,14 @@ export default function ImageEditorTool({
           flexDirection="column"
           onClick={handleClick}
           justifyContent="center"
+          overflowY="auto"
           position="relative"
           top={{ base: '40px', md: 0 }}
         >
           <Box
             id="#canvas-container-front"
             display={selectedSide === 'front' ? 'block' : 'none'}
+            maxHeight="100%"
             position="relative"
             userSelect="none"
           >
@@ -530,6 +532,7 @@ export default function ImageEditorTool({
           <Box
             id="#canvas-container-back"
             display={selectedSide === 'back' ? 'block' : 'none'}
+            maxHeight="100%"
             position="relative"
           >
             <CanvasContainer


### PR DESCRIPTION
### Description (what's changed?)

Set max height and overflow to template image

### Testing instructions

1. Open the template details for a sleeveless hoodie. The image is big but it will fit inside the screen and you'll be able to scroll vertically. 
