### PR TITLE
Hide style hint on desktop

### DIFF
--- a/src/views/app/editor/components/CanvasContainer.tsx
+++ b/src/views/app/editor/components/CanvasContainer.tsx
@@ -145,6 +145,7 @@ const CanvasContainer = ({
           <Flex
             align="center"
             as="button"
+            display={{ base: 'flex', md: 'none' }}
             direction="column"
             justify="center"
             onClick={(e) => {


### PR DESCRIPTION
### Description (what's changed?)

### Testing instructions

1. Open the editor on desktop. There's no Choose style hint.
