### PR TITLE
New template selection flow

### DIFF
--- a/src/views/app/editor/EditorTool.tsx
+++ b/src/views/app/editor/EditorTool.tsx
@@ -8,6 +8,7 @@ import { isEmpty, partition } from 'lodash';
 import { AiImage, Design, Garment, Template } from '@/components/types';
 
 import CanvasContainer from './components/CanvasContainer';
+import ColorPicker from './components/ColorPicker';
 import Toolbar from './controls';
 
 import ObjectEditTools from './object-edit-tools';
@@ -511,6 +512,18 @@ export default function ImageEditorTool({
           position="relative"
           top={{ base: '40px', md: 0 }}
         >
+          <Box position="absolute" right="13px" top="12px">
+            <ColorPicker
+              selectedVariantId={templateColorId}
+              onSelectedVariant={(variantId) =>
+                onDesignChange({
+                  ...design,
+                  templateColorId: variantId,
+                })
+              }
+              options={template.colors}
+            />
+          </Box>
           <Box
             id="#canvas-container-front"
             display={selectedSide === 'front' ? 'block' : 'none'}

--- a/src/views/app/editor/EditorTool.tsx
+++ b/src/views/app/editor/EditorTool.tsx
@@ -509,8 +509,8 @@ export default function ImageEditorTool({
           onClick={handleClick}
           justifyContent="center"
           overflowY="auto"
+          paddingTop={{ base: '40px', md: 0 }}
           position="relative"
-          top={{ base: '40px', md: 0 }}
         >
           <Box position="absolute" right="13px" top="12px">
             <ColorPicker

--- a/src/views/app/editor/components/ColorPicker.tsx
+++ b/src/views/app/editor/components/ColorPicker.tsx
@@ -1,0 +1,91 @@
+import { Box, Button, HStack } from '@chakra-ui/react';
+
+import { ColorVariant } from '@/components/types';
+
+import Colors from '@/theme/colors';
+import { useState } from 'react';
+
+const { abloBlue } = Colors;
+
+const ButtonSelectColor = (props) => (
+  <Button
+    h="24px"
+    flexShrink={0}
+    padding="0"
+    w="24px"
+    borderRadius="50%"
+    minWidth="auto"
+    {...props}
+  />
+);
+
+const ButtonLink = (props) => (
+  <Button
+    bg="transparent"
+    color="#397ADC"
+    fontSize="13px"
+    fontWeight={500}
+    h="16px"
+    minWidth="none"
+    p={0}
+    width="auto"
+    {...props}
+  />
+);
+
+type Props = {
+  selectedVariantId: string;
+  onSelectedVariant: (value: string) => void;
+  options: ColorVariant[];
+};
+
+const ColorPicker = ({ selectedVariantId, onSelectedVariant, options }: Props) => {
+  const [isPickerVisible, setPickerVisible] = useState(false);
+
+  const selectedVariant = options.find(({ id }) => id === selectedVariantId);
+
+  return (
+    <Box
+      borderRadius="50px"
+      border="1px solid #DDD"
+      background="#FFFFFF"
+      h="36px"
+      padding="5px 8px"
+    >
+      {isPickerVisible ? (
+        <HStack>
+          {options.map(({ id, name, hex }) => {
+            const isSelected = selectedVariantId === id;
+
+            return (
+              <ButtonSelectColor
+                bg={hex}
+                border={
+                  isSelected
+                    ? `1px solid ${abloBlue}`
+                    : name === 'Blanco'
+                    ? '1px solid #D9D9D9'
+                    : 'none'
+                }
+                key={id}
+                onClick={(e) => {
+                  e.stopPropagation();
+
+                  onSelectedVariant(id);
+                }}
+              />
+            );
+          })}
+          <ButtonLink onClick={() => setPickerVisible(false)}>Done</ButtonLink>
+        </HStack>
+      ) : (
+        <HStack>
+          <Box bg={selectedVariant.hex} width="26px" height="26px" borderRadius="50%" />
+          <ButtonLink onClick={() => setPickerVisible(true)}>Change</ButtonLink>
+        </HStack>
+      )}
+    </Box>
+  );
+};
+
+export default ColorPicker;

--- a/src/views/app/editor/toolbar/template-picker/Icons.tsx
+++ b/src/views/app/editor/toolbar/template-picker/Icons.tsx
@@ -16,72 +16,32 @@ export const IconFilters = () => (
           strokeLinecap="round"
           strokeLinejoin="round"
         />
-        <path
-          d="M6 4.66313V8.66313"
-          stroke="black"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-        <path
-          d="M6 12.6631V20.6631"
-          stroke="black"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
+        <path d="M6 4.66313V8.66313" stroke="black" strokeLinecap="round" strokeLinejoin="round" />
+        <path d="M6 12.6631V20.6631" stroke="black" strokeLinecap="round" strokeLinejoin="round" />
         <path
           d="M10 14.6631H14V18.6631H10V14.6631Z"
           stroke="black"
           strokeLinecap="round"
           strokeLinejoin="round"
         />
-        <path
-          d="M12 4.66313V14.6631"
-          stroke="black"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-        <path
-          d="M12 18.6631V20.6631"
-          stroke="black"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
+        <path d="M12 4.66313V14.6631" stroke="black" strokeLinecap="round" strokeLinejoin="round" />
+        <path d="M12 18.6631V20.6631" stroke="black" strokeLinecap="round" strokeLinejoin="round" />
         <path
           d="M16 5.66313H20V9.66313H16V5.66313Z"
           stroke="black"
           strokeLinecap="round"
           strokeLinejoin="round"
         />
-        <path
-          d="M18 4.66313V5.66313"
-          stroke="black"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-        <path
-          d="M18 9.66313V20.6631"
-          stroke="black"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
+        <path d="M18 4.66313V5.66313" stroke="black" strokeLinecap="round" strokeLinejoin="round" />
+        <path d="M18 9.66313V20.6631" stroke="black" strokeLinecap="round" strokeLinejoin="round" />
       </g>
     </g>
     <defs>
       <clipPath id="clip0_354_236">
-        <rect
-          width="24"
-          height="24"
-          fill="white"
-          transform="translate(0 0.663132)"
-        />
+        <rect width="24" height="24" fill="white" transform="translate(0 0.663132)" />
       </clipPath>
       <clipPath id="clip1_354_236">
-        <rect
-          width="24"
-          height="24"
-          fill="white"
-          transform="translate(0 0.663132)"
-        />
+        <rect width="24" height="24" fill="white" transform="translate(0 0.663132)" />
       </clipPath>
     </defs>
   </Icon>
@@ -132,34 +92,12 @@ export const IconSustainable = (props) => (
         strokeLinecap="round"
         strokeLinejoin="round"
       />
-      <path
-        d="M12 15V9"
-        stroke="#6A6866"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
+      <path d="M12 15V9" stroke="#6A6866" strokeLinecap="round" strokeLinejoin="round" />
     </g>
     <defs>
       <clipPath id="clip0_1384_4224">
         <rect width="24" height="24" fill="white" />
       </clipPath>
     </defs>
-  </Icon>
-);
-
-export const IconSelected = (props) => (
-  <Icon
-    width="22px"
-    height="23px"
-    viewBox="0 0 22 23"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-    {...props}
-  >
-    <circle cx="11" cy="11.3369" r="8.90476" fill="white" />
-    <path
-      d="M11.0002 2.17041C5.94016 2.17041 1.8335 6.27708 1.8335 11.3371C1.8335 16.3971 5.94016 20.5037 11.0002 20.5037C16.0602 20.5037 20.1668 16.3971 20.1668 11.3371C20.1668 6.27708 16.0602 2.17041 11.0002 2.17041ZM9.16683 15.9204L4.5835 11.3371L5.876 10.0446L9.16683 13.3262L16.1243 6.36874L17.4168 7.67041L9.16683 15.9204Z"
-      fill="#064AC4"
-    />
   </Icon>
 );

--- a/src/views/app/editor/toolbar/template-picker/index.tsx
+++ b/src/views/app/editor/toolbar/template-picker/index.tsx
@@ -1,6 +1,6 @@
 import { Fragment as F, useState } from 'react';
 
-import { Box, Button, Flex, Image, Text, useBreakpointValue } from '@chakra-ui/react';
+import { Box, Button, Flex, HStack, Image, Text, useBreakpointValue } from '@chakra-ui/react';
 
 import { chunk } from 'lodash';
 
@@ -15,7 +15,7 @@ import TemplateDetails from './TemplateDetails';
 import TemplateFilters from './Filters';
 import { getOptions } from './utils';
 
-import { IconFilters, IconCloseFilters, IconSustainable, IconSelected } from './Icons';
+import { IconFilters, IconCloseFilters } from './Icons';
 
 const { abloBlue } = Colors;
 
@@ -64,8 +64,11 @@ const TemplatesList = ({ templates, onSelectedTemplate, selectedGarment }: Templ
 
             const isSelected = selectedGarment && selectedGarment.templateId === id;
 
+            const selectedColor =
+              isSelected && colors.find((variant) => variant.id === selectedGarment.variantId).hex;
+
             const selectedProps = isSelected
-              ? { border: '2px solid #000000', borderRadius: '10px' }
+              ? { border: '1px solid #BABABA', borderRadius: '10px' }
               : {};
 
             return (
@@ -75,13 +78,7 @@ const TemplatesList = ({ templates, onSelectedTemplate, selectedGarment }: Templ
                 marginLeft={`${index === 0 ? 0 : 8}px`}
                 onClick={() => onSelectedTemplate(template)}
                 position="relative"
-                {...selectedProps}
               >
-                {isSelected ? (
-                  <IconSelected position="absolute" top="8px" right="8px" />
-                ) : (
-                  <IconSustainable position="absolute" top="8px" right="8px" />
-                )}
                 <Flex
                   align="center"
                   bg="#F9F9F7"
@@ -89,8 +86,25 @@ const TemplatesList = ({ templates, onSelectedTemplate, selectedGarment }: Templ
                   h="180px"
                   justify="center"
                   padding="16px 8px"
+                  position="relative"
+                  {...selectedProps}
                 >
                   <Image h={160} src={`${variant?.images[0]?.url}`} alt={name} />
+                  {isSelected ? (
+                    <HStack
+                      borderRadius="50px"
+                      border="1px solid #DDD"
+                      bottom="1"
+                      background="#FFFFFF"
+                      padding="5px 8px"
+                      position="absolute"
+                    >
+                      <Box bg={selectedColor} borderRadius="50%" width="26px" height="26px" />
+                      <Text color="#828282" fontSize="13px" fontWeight={500}>
+                        Selected
+                      </Text>
+                    </HStack>
+                  ) : null}
                 </Flex>
                 <Box padding="8px">
                   <Text color="#6A6866" display="block" fontSize="xs" textTransform="uppercase">


### PR DESCRIPTION
### Description (what's changed?)

New template selection flow

### Testing instructions

1.  The selected template has a black outline.
2. Color selection should not change the template library color but just show an icon with the selected color as seen below.
3. A new color picker is added on the editor and it allows you to change the color without going to template details. It behaves like in this video:

https://spacerunnersworkspace.slack.com/files/U05F0PB8EQN/F05Q1C13F0S/itemcolorchange.mov
