### PR TITLE
Disable quick save on new designs

### DIFF
--- a/src/views/app/editor/EditorTool.tsx
+++ b/src/views/app/editor/EditorTool.tsx
@@ -452,6 +452,7 @@ export default function ImageEditorTool({
           />
         ) : (
           <Toolbar
+            design={design}
             onAddText={handleAddText}
             onSelectedSide={handleSelectedSide}
             onUndo={undoHandler}

--- a/src/views/app/editor/controls/index.tsx
+++ b/src/views/app/editor/controls/index.tsx
@@ -4,6 +4,7 @@ import ToolbarButton from '../components/ToolbarButton';
 
 import IconUndo from '@/components/icons/IconUndo';
 import IconRedo from '@/components/icons/IconRedo';
+import { Design } from '@/components/types';
 
 import ToolbarContainer from '../components/ToolbarContainer';
 
@@ -26,6 +27,7 @@ const textProps = {
 };
 
 type Props = {
+  design: Design;
   onAddText: (props: object) => void;
   onSelectedSide: (side: string) => void;
   onUndo?: () => void;
@@ -35,6 +37,7 @@ type Props = {
 };
 
 export default function Toolbar({
+  design,
   onAddText,
   onSelectedSide,
   onUndo,
@@ -77,7 +80,7 @@ export default function Toolbar({
             onClick={onRedo}
             text="Redo"
           />
-          <ToolbarButton icon={<IconSave />} onClick={onSave} text="Save" />
+          {design.id ? <ToolbarButton icon={<IconSave />} onClick={onSave} text="Save" /> : null}
         </HStack>
       </HStack>
     </ToolbarContainer>


### PR DESCRIPTION
### Description (what's changed?)

Removed the Quicksave button when you're creating a new design. This solves the issue.

### Testing instructions

1. Clear access tokens from local storage. Try to create a new design as a guest. You won't see the quick save button. You have to go through Finish&Share which will prompt you to login if you're a guest

