### PR TITLE
Hide style picker when only one style

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ablo-demo-fe",
   "description": "A tool that lets you put AI generated designs on templates like clothes, with a full fledged text and image editor",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "type": "module",
   "license": "MIT",
   "homepage": "web.ablo.ai",

--- a/src/lib/editor/toolbar/image-generator/index.tsx
+++ b/src/lib/editor/toolbar/image-generator/index.tsx
@@ -71,7 +71,13 @@ export default function ImageGenerator({
   const style = styles.find(({ id }) => id === styleId);
 
   useEffect(() => {
-    getStyles().then(setStyles);
+    getStyles().then((styles) => {
+      setStyles(styles);
+
+      if (styles?.length === 1) {
+        setOptions((options) => ({ ...options, styleId: styles[0].id }));
+      }
+    });
   }, [getStyles]);
 
   const handleNewArtwork = () => {
@@ -88,7 +94,13 @@ export default function ImageGenerator({
   const handleReset = () => {
     setImages([]);
     setSelectedImage(null);
-    setOptions(defaultParams);
+
+    const options = { ...defaultParams };
+
+    if (styles?.length === 1) {
+      options.styleId = styles[0].id;
+    }
+    setOptions(options);
   };
 
   const handleUpdateKeywords = (newKeywords) => {
@@ -192,53 +204,57 @@ export default function ImageGenerator({
         }
       }}
     >
-      <Text as="b" fontSize="md" mb="5px" ml="14px">
-        Text to Image
-      </Text>
-      <Accordion defaultIndex={[0, 1]} allowMultiple>
-        <AccordionItem borderTopWidth={0} paddingBottom="8px">
-          <h2>
-            <AccordionButton {...accordionButtonStyles}>
-              <Box as="span" flex="1" fontSize="sm" textAlign="left">
-                Style
-              </Box>
-              <AccordionIcon />
-            </AccordionButton>
-          </h2>
-          <AccordionPanel pb={4}>
-            <SelectStyle
-              onChange={(styleId) => {
-                tonesRef.current?.scrollIntoView({ behavior: 'smooth' });
+      {styles.length > 1 ? (
+        <Box>
+          <Text as="b" fontSize="md" mb="5px" ml="14px">
+            Text to Image
+          </Text>
+          <Accordion defaultIndex={[0, 1]} allowMultiple>
+            <AccordionItem borderTopWidth={0} paddingBottom="8px">
+              <h2>
+                <AccordionButton {...accordionButtonStyles}>
+                  <Box as="span" flex="1" fontSize="sm" textAlign="left">
+                    Style
+                  </Box>
+                  <AccordionIcon />
+                </AccordionButton>
+              </h2>
+              <AccordionPanel pb={4}>
+                <SelectStyle
+                  onChange={(styleId) => {
+                    tonesRef.current?.scrollIntoView({ behavior: 'smooth' });
 
-                handleUpdate({ styleId });
-              }}
-              options={styles}
-              selectedValue={styleId}
-            />
-          </AccordionPanel>
-        </AccordionItem>
-        <AccordionItem borderColor="transparent" borderTopWidth={0} paddingBottom="10px">
-          <h2>
-            <AccordionButton {...accordionButtonStyles}>
-              <Box as="span" flex="1" fontSize="sm" textAlign="left" ref={tonesRef}>
-                Color Filter
-              </Box>
-              <AccordionIcon />
-            </AccordionButton>
-          </h2>
-          <AccordionPanel pb={4}>
-            <SelectColorPalette
-              onChange={(toneId) => {
-                subjectInputRef.current?.focus();
+                    handleUpdate({ styleId });
+                  }}
+                  options={styles}
+                  selectedValue={styleId}
+                />
+              </AccordionPanel>
+            </AccordionItem>
+            <AccordionItem borderColor="transparent" borderTopWidth={0} paddingBottom="10px">
+              <h2>
+                <AccordionButton {...accordionButtonStyles}>
+                  <Box as="span" flex="1" fontSize="sm" textAlign="left" ref={tonesRef}>
+                    Color Filter
+                  </Box>
+                  <AccordionIcon />
+                </AccordionButton>
+              </h2>
+              <AccordionPanel pb={4}>
+                <SelectColorPalette
+                  onChange={(toneId) => {
+                    subjectInputRef.current?.focus();
 
-                handleUpdate({ toneId });
-              }}
-              selectedValue={toneId}
-              style={style}
-            />
-          </AccordionPanel>
-        </AccordionItem>
-      </Accordion>
+                    handleUpdate({ toneId });
+                  }}
+                  selectedValue={toneId}
+                  style={style}
+                />
+              </AccordionPanel>
+            </AccordionItem>
+          </Accordion>
+        </Box>
+      ) : null}
       <AddSubject
         background={background}
         onChangeBackground={(background) => handleUpdate({ background })}


### PR DESCRIPTION
### Description (what's changed?)

This hides the style picker and selects the first and only style as default when there's only one style. 

### Testing instructions

1. To test it you can mock the styles endpoint return to only give you one style: 

```
export const getStyles = (baseUrl = '') =>
  axios.get<Style[]>(`${baseUrl || ''}/styles`).then(({ data }) => data.slice(0, 1));
```
