### PR TITLE
Move color picker modal a little bit to the left

### DIFF
--- a/src/lib/components/modals/ColorPickerModal.tsx
+++ b/src/lib/components/modals/ColorPickerModal.tsx
@@ -14,7 +14,16 @@ const ColorPickerModal = ({ onClose, onSelectedColor, selectedColor }: Props) =>
   return (
     <Modal isOpen={true} onClose={onClose} motionPreset="slideInBottom">
       <ModalOverlay />
-      <ModalContent alignSelf="center" borderRadius="10px" h="450px" w="328px">
+      <ModalContent
+        alignSelf="center"
+        borderRadius="10px"
+        h="450px"
+        w="328px"
+        containerProps={{
+          justifyContent: { md: 'flex-start', base: 'center' },
+          paddingLeft: { md: '20rem', base: 0 },
+        }}
+      >
         <ModalBody padding="15px 12px">
           <Flex alignItems="center" justifyContent="space-between" mb="20px">
             <Text as="b" fontSize="sm">


### PR DESCRIPTION
### Description (what's changed?)

Moves color picker modal a to the left so Max can see the entire text on the garment. Just a disclaimer: I personally don't think it's an issue.


