### PR TITLE
Fallback for empty design

### DIFF
--- a/src/views/app/designs/index.tsx
+++ b/src/views/app/designs/index.tsx
@@ -89,7 +89,7 @@ const DesignsList = ({ designs, onSelectedDesign, templates }: DesignsListProps)
           const images =
             (template && template.colors.find(({ id }) => id === templateColorId).images) || [];
 
-          const side = sides.find(({ hasGraphics, hasText }) => hasGraphics || hasText) || {};
+          const side = sides.find(({ hasGraphics, hasText }) => hasGraphics || hasText) || sides[0];
 
           const { imageUrl, templateSideId } = side;
 


### PR DESCRIPTION
### Description (what's changed?)

I noticed that on my account on production the designs page wasn't working because I'm not handling empty designs well.

